### PR TITLE
Nifty/guess to remote anchors

### DIFF
--- a/bitcoin/psbt.c
+++ b/bitcoin/psbt.c
@@ -445,42 +445,42 @@ bool psbt_input_set_redeemscript(struct wally_psbt *psbt, size_t in,
 void psbt_input_hash_for_sig(struct wally_psbt *psbt, size_t in,
 			     struct sha256_double *dest)
 {
-       int ret;
-       u8 value[9];
-       u64 input_val_sats;
-       struct amount_sat input_amt;
-       int flags = WALLY_TX_FLAG_USE_WITNESS;
+	int ret;
+	u8 value[9];
+	u64 input_val_sats;
+	struct amount_sat input_amt;
+	int flags = WALLY_TX_FLAG_USE_WITNESS;
 
-       input_amt = psbt_input_get_amount(psbt, in);
-       input_val_sats = input_amt.satoshis; /* Raw: type conversion */
+	input_amt = psbt_input_get_amount(psbt, in);
+	input_val_sats = input_amt.satoshis; /* Raw: type conversion */
 
        /* Wally can allocate here, iff tx doesn't fit on stack */
-       tal_wally_start();
-       if (is_elements(chainparams)) {
-               ret = wally_tx_confidential_value_from_satoshi(input_val_sats, value, sizeof(value));
-               assert(ret == WALLY_OK);
-               ret = wally_tx_get_elements_signature_hash(
-                   psbt->tx, in,
-                   /* assume segwit */
-                   psbt->inputs[in].witness_script,
-                   psbt->inputs[in].witness_script_len,
-                   value, sizeof(value),
-                   psbt->inputs[in].sighash,
-                   flags, dest->sha.u.u8,
-                   sizeof(*dest));
-               assert(ret == WALLY_OK);
-       } else {
-               ret = wally_tx_get_btc_signature_hash(
-                   psbt->tx, in,
-                   /* assume segwit */
-                   psbt->inputs[in].witness_script,
-                   psbt->inputs[in].witness_script_len,
-                   input_val_sats,
-                   psbt->inputs[in].sighash,
-                   flags, dest->sha.u.u8, sizeof(*dest));
-               assert(ret == WALLY_OK);
-       }
-       tal_wally_end(psbt);
+	tal_wally_start();
+	if (is_elements(chainparams)) {
+	        ret = wally_tx_confidential_value_from_satoshi(input_val_sats, value, sizeof(value));
+	        assert(ret == WALLY_OK);
+	        ret = wally_tx_get_elements_signature_hash(
+	                psbt->tx, in,
+	                /* assume segwit */
+	                psbt->inputs[in].witness_script,
+	                psbt->inputs[in].witness_script_len,
+	                value, sizeof(value),
+	                psbt->inputs[in].sighash,
+	                flags, dest->sha.u.u8,
+	                sizeof(*dest));
+        	assert(ret == WALLY_OK);
+	} else {
+                ret = wally_tx_get_btc_signature_hash(
+			psbt->tx, in,
+	                /* assume segwit */
+	                psbt->inputs[in].witness_script,
+	                psbt->inputs[in].witness_script_len,
+	                input_val_sats,
+	                psbt->inputs[in].sighash,
+	                flags, dest->sha.u.u8, sizeof(*dest));
+                assert(ret == WALLY_OK);
+	}
+	tal_wally_end(psbt);
 }
 
 struct amount_sat psbt_input_get_amount(const struct wally_psbt *psbt,

--- a/tests/test_wallet.py
+++ b/tests/test_wallet.py
@@ -1218,7 +1218,7 @@ def test_hsmtool_guess_to_remote_non_anchor(node_factory, bitcoind):
     sync_blockheight(bitcoind, [l2])
     log = l2.daemon.wait_for_log(r'Script to-them: ')
     m = re.search(r'Script to-them: ([a-f0-9]{44})', log)
-    onchain_addr = bitcoind.rpc.decodescript(m.group(1))['address']
+    onchain_addr = bitcoind.rpc.decodescript(m.group(1))['segwit']['address']
 
     # Now try using the hsmtool to find the thing
     hsm_path = os.path.join(l1.daemon.lightning_dir, TEST_NETWORK, "hsm_secret")
@@ -1234,7 +1234,7 @@ def test_hsmtool_guess_to_remote_non_anchor(node_factory, bitcoind):
 
 @unittest.skipIf(TEST_NETWORK == 'liquid-regtest', 'v2 channels not available')
 @pytest.mark.openchannel('v2')
-@pytest.mark.developer("requres 'dev-queryrates'")
+@pytest.mark.developer("requires 'dev-queryrates'")
 def test_hsmtool_guess_to_remote_anchor(node_factory, bitcoind):
     opts = {'funder-policy': 'match', 'funder-policy-mod': 100,
             'lease-fee-base-msat': '100sat', 'lease-fee-basis': 100,

--- a/tools/hsmtool.c
+++ b/tools/hsmtool.c
@@ -432,7 +432,7 @@ static int guess_to_remote(const char *address, struct node_id *node_id,
 		 * block csv lock.
 		 *    <remote_pubkey> OP_CHECKSIGVERIFY 1 OP_CHECKSEQUENCEVERIFY
 		 */
-		/* BOLT- #3
+		/* BOLT-cb691777fb4263eadb68e6a8331ccadd14aa9793 #3
 		 * ##### Leased channel (`option_will_fund`)
 		 *
 		 * If a `lease` applies to the channel, the `to_remote` output
@@ -464,7 +464,7 @@ static int guess_to_remote(const char *address, struct node_id *node_id,
 		}
 	}
 
-	printf("Could not find any basepoint matching the provided witness programm.\n"
+	printf("Could not find any basepoint matching the provided witness program.\n"
 	       "Are you sure that the channel used `option_static_remotekey` ?\n");
 	return 1;
 }


### PR DESCRIPTION
Spelling and whitespace cleanup. Also got test_wallet.py::hsmtool_guess_to_remote_non_anchor a little closer to testing.