### PR TITLE
bkpr: add examples for new edit description RPC calls

### DIFF
--- a/contrib/msggen/msggen/schema.json
+++ b/contrib/msggen/msggen/schema.json
@@ -2296,7 +2296,47 @@
       "resources": [
         "Main web site: <https://github.com/ElementsProject/lightning>"
       ],
-      "examples": []
+      "examples": [
+        {
+          "request": {
+            "id": "example:bkpr-editdescriptionbyoutpoint#1",
+            "method": "bkpr-editdescriptionbyoutpoint",
+            "params": {
+              "outpoint": "55edd73a01f08057e1f5f61788477c0d7551d5d1aa2f2907bf9d03b6370bbacf:1",
+              "description": "edited utxo description"
+            }
+          },
+          "response": {
+            "updated": [
+              {
+                "account": "wallet",
+                "type": "chain",
+                "tag": "deposit",
+                "credit_msat": 200000000000,
+                "debit_msat": 0,
+                "currency": "bcrt",
+                "outpoint": "55edd73a01f08057e1f5f61788477c0d7551d5d1aa2f2907bf9d03b6370bbacf:1",
+                "timestamp": 1724554221,
+                "blockheight": 105,
+                "description": "edited utxo description"
+              }
+            ]
+          }
+        },
+        {
+          "request": {
+            "id": "example:bkpr-editdescriptionbyoutpoint#2",
+            "method": "bkpr-editdescriptionbyoutpoint",
+            "params": {
+              "outpoint": "6472b4c9d39d8478ed9c848df7a62a512d953a4b2e6e7b09902d76a7bbb761ca:1",
+              "description": "edited utxo description"
+            }
+          },
+          "response": {
+            "updated": []
+          }
+        }
+      ]
     },
     "lightning-bkpr-editdescriptionbypaymentid.json": {
       "$schema": "../rpc-schema-draft.json",
@@ -2559,7 +2599,48 @@
       "resources": [
         "Main web site: <https://github.com/ElementsProject/lightning>"
       ],
-      "examples": []
+      "examples": [
+        {
+          "request": {
+            "id": "example:bkpr-editdescriptionbypaymentid#1",
+            "method": "bkpr-editdescriptionbypaymentid",
+            "params": {
+              "payment_id": "6ff673c6ae3527726cf200274426db79f93054a3cbbc4b3787d1afc2d65565a7",
+              "description": "edited invoice description"
+            }
+          },
+          "response": {
+            "updated": [
+              {
+                "account": "a397dd9b3e44afcb67f3f3ce1d649b74a8ade63e35505985e4cc1828634f69a2",
+                "type": "channel",
+                "tag": "invoice",
+                "credit_msat": 500000000,
+                "debit_msat": 0,
+                "currency": "bcrt",
+                "payment_id": "6ff673c6ae3527726cf200274426db79f93054a3cbbc4b3787d1afc2d65565a7",
+                "part_id": 0,
+                "timestamp": 1724554257,
+                "description": "edited invoice description",
+                "is_rebalance": false
+              }
+            ]
+          }
+        },
+        {
+          "request": {
+            "id": "example:bkpr-editdescriptionbypaymentid#2",
+            "method": "bkpr-editdescriptionbypaymentid",
+            "params": {
+              "payment_id": "c97b61113636256111835c0204d70111c42f19069cefdc659849a6afc6b595a4",
+              "description": "edited invoice description"
+            }
+          },
+          "response": {
+            "updated": []
+          }
+        }
+      ]
     },
     "lightning-bkpr-inspect.json": {
       "$schema": "../rpc-schema-draft.json",

--- a/doc/schemas/lightning-bkpr-editdescriptionbyoutpoint.json
+++ b/doc/schemas/lightning-bkpr-editdescriptionbyoutpoint.json
@@ -45,7 +45,7 @@
             "debit_msat",
             "currency",
             "timestamp",
-	    "description"
+            "description"
           ],
           "properties": {
             "account": {
@@ -127,7 +127,7 @@
                     "description": [
                       "A description of this outpoint."
                     ]
-		  },
+                  },
                   "outpoint": {
                     "type": "string",
                     "description": [
@@ -266,5 +266,44 @@
     "Main web site: <https://github.com/ElementsProject/lightning>"
   ],
   "examples": [
+    {
+      "request": {
+        "id": "example:bkpr-editdescriptionbyoutpoint#1",
+        "method": "bkpr-editdescriptionbyoutpoint",
+        "params": {
+          "outpoint": "55edd73a01f08057e1f5f61788477c0d7551d5d1aa2f2907bf9d03b6370bbacf:1",
+          "description": "edited utxo description"
+        }
+      },
+      "response": {
+        "updated": [
+          {
+            "account": "wallet",
+            "type": "chain",
+            "tag": "deposit",
+            "credit_msat": 200000000000,
+            "debit_msat": 0,
+            "currency": "bcrt",
+            "outpoint": "55edd73a01f08057e1f5f61788477c0d7551d5d1aa2f2907bf9d03b6370bbacf:1",
+            "timestamp": 1724554221,
+            "blockheight": 105,
+            "description": "edited utxo description"
+          }
+        ]
+      }
+    },
+    {
+      "request": {
+        "id": "example:bkpr-editdescriptionbyoutpoint#2",
+        "method": "bkpr-editdescriptionbyoutpoint",
+        "params": {
+          "outpoint": "6472b4c9d39d8478ed9c848df7a62a512d953a4b2e6e7b09902d76a7bbb761ca:1",
+          "description": "edited utxo description"
+        }
+      },
+      "response": {
+        "updated": []
+      }
+    }
   ]
 }

--- a/doc/schemas/lightning-bkpr-editdescriptionbypaymentid.json
+++ b/doc/schemas/lightning-bkpr-editdescriptionbypaymentid.json
@@ -45,7 +45,7 @@
             "debit_msat",
             "currency",
             "timestamp",
-	    "description"
+            "description"
           ],
           "properties": {
             "account": {
@@ -260,5 +260,45 @@
     "Main web site: <https://github.com/ElementsProject/lightning>"
   ],
   "examples": [
+    {
+      "request": {
+        "id": "example:bkpr-editdescriptionbypaymentid#1",
+        "method": "bkpr-editdescriptionbypaymentid",
+        "params": {
+          "payment_id": "6ff673c6ae3527726cf200274426db79f93054a3cbbc4b3787d1afc2d65565a7",
+          "description": "edited invoice description"
+        }
+      },
+      "response": {
+        "updated": [
+          {
+            "account": "a397dd9b3e44afcb67f3f3ce1d649b74a8ade63e35505985e4cc1828634f69a2",
+            "type": "channel",
+            "tag": "invoice",
+            "credit_msat": 500000000,
+            "debit_msat": 0,
+            "currency": "bcrt",
+            "payment_id": "6ff673c6ae3527726cf200274426db79f93054a3cbbc4b3787d1afc2d65565a7",
+            "part_id": 0,
+            "timestamp": 1724554257,
+            "description": "edited invoice description",
+            "is_rebalance": false
+          }
+        ]
+      }
+    },
+    {
+      "request": {
+        "id": "example:bkpr-editdescriptionbypaymentid#2",
+        "method": "bkpr-editdescriptionbypaymentid",
+        "params": {
+          "payment_id": "c97b61113636256111835c0204d70111c42f19069cefdc659849a6afc6b595a4",
+          "description": "edited invoice description"
+        }
+      },
+      "response": {
+        "updated": []
+      }
+    }
   ]
 }

--- a/plugins/bkpr/bookkeeper.c
+++ b/plugins/bkpr/bookkeeper.c
@@ -500,7 +500,7 @@ static struct command_result *json_edit_desc_utxo(struct command *cmd,
 	struct chain_event **chain_events;
 
 	if (!param(cmd, buf, params,
-		   p_req("identifier", param_outpoint, &outpoint),
+		   p_req("outpoint", param_outpoint, &outpoint),
 		   p_req("description", param_string, &new_desc),
 		   NULL))
 		return command_param_failed();

--- a/tests/autogenerate-rpc-examples.py
+++ b/tests/autogenerate-rpc-examples.py
@@ -483,7 +483,18 @@ def generate_bookkeeper_examples(l2, l3, c23_chan_id):
         update_example(node=l3, method='bkpr-listaccountevents', params={})
         update_example(node=l3, method='bkpr-listaccountevents', params=[c23_chan_id])
         update_example(node=l3, method='bkpr-listincome', params={})
-        update_example(node=l3, method='bkpr-listincome', params={'consolidate_fees': False})
+
+        # listincome and editing descriptions
+        listincome_result = update_example(node=l3, method='bkpr-listincome', params={'consolidate_fees': False})
+        invoice = next((event for event in listincome_result['income_events'] if 'payment_id' in event), None)
+        utxo_event = next((event for event in listincome_result['income_events'] if 'outpoint' in event), None)
+        update_example(node=l3, method='bkpr-editdescriptionbypaymentid', params={'payment_id': invoice['payment_id'], 'description': 'edited invoice description'})
+        # Try to edit a payment_id that does not exist
+        update_example(node=l3, method='bkpr-editdescriptionbypaymentid', params={'payment_id': 'c97b61113636256111835c0204d70111c42f19069cefdc659849a6afc6b595a4', 'description': 'edited invoice description'})
+        update_example(node=l3, method='bkpr-editdescriptionbyoutpoint', params={'outpoint': utxo_event['outpoint'], 'description': 'edited utxo description'})
+        # Try to edit an outpoint that does not exist
+        update_example(node=l3, method='bkpr-editdescriptionbyoutpoint', params={'outpoint': '6472b4c9d39d8478ed9c848df7a62a512d953a4b2e6e7b09902d76a7bbb761ca:1', 'description': 'edited utxo description'})
+
         logger.info('Bookkeeper Done!')
     except TaskFinished:
         raise


### PR DESCRIPTION
Adds examples and fixes the 'outpoint' param in bookkeeper.c to match the schema which is no longer 'identifier' but is now 'outpoint'.